### PR TITLE
fix vocabulary size bug

### DIFF
--- a/src/language_models/dictionary_corpus.py
+++ b/src/language_models/dictionary_corpus.py
@@ -25,6 +25,8 @@ class Dictionary(object):
         except FileNotFoundError:
             logging.info("Vocab file not found, creating new vocab file.")
             self.create_vocab(os.path.join(path, 'train.txt'))
+            self.create_vocab(os.path.join(path, 'valid.txt'))
+            self.create_vocab(os.path.join(path, 'test.txt'))
             open(vocab_path,"w").write("\n".join([w for w in self.idx2word]))
 
     def add_word(self, word):


### PR DESCRIPTION
Hi Sheng-fu:

My team is replicating you Blimp paper. Your code helped me a lot. Thank you.
I assume that your code should be compatible with these [data and pretrained model](https://github.com/miaomiaosang/colorlessgreenRNNs/blob/master/data) you mentioned in data section. While using your code I found that in evaluate_target_word_no_mask_per_word.py, the reshape function(output.view) on line 69 cannot work well when using the pytorch offical LM example output model (https://github.com/pytorch/examples/tree/master/word_language_model). This is because in the pytorch example, the vocabulary is constituted by the types from train valid and test sets. In your code you only counted vocabulary from train set.

I'm very grateful that you provided thses code and I would be happy if my effort could be useful to your code.

Best regards
Yu Li